### PR TITLE
Update generator ping handler

### DIFF
--- a/cmd/hz/generator/layout_tpl.go
+++ b/cmd/hz/generator/layout_tpl.go
@@ -138,9 +138,9 @@ import (
 
 // Ping .
 func Ping(ctx context.Context, c *app.RequestContext) {
-	c.JSON(consts.StatusOK, utils.H{
-		"message": "pong",
-	})
+       c.JSON(consts.StatusOK, utils.H{
+               "ping": "aoisefjoaeiwhfuifh",
+       })
 }
 `,
 		},

--- a/examples/standard/main.go
+++ b/examples/standard/main.go
@@ -36,7 +36,7 @@ func main() {
 	h.StaticFS("/", &app.FS{Root: "./", GenerateIndexPages: true})
 
 	h.GET("/ping", func(c context.Context, ctx *app.RequestContext) {
-		ctx.JSON(consts.StatusOK, utils.H{"ping": "pong"})
+		ctx.JSON(consts.StatusOK, utils.H{"ping": "aoisefjoaeiwhfuifh"})
 	})
 
 	h.GET("/json", func(c context.Context, ctx *app.RequestContext) {

--- a/pkg/common/config/option.go
+++ b/pkg/common/config/option.go
@@ -34,7 +34,7 @@ type Option struct {
 const (
 	defaultKeepAliveTimeout   = 1 * time.Minute
 	defaultReadTimeout        = 3 * time.Minute
-	defaultAddr               = ":8888"
+	defaultAddr               = ":8899"
 	defaultNetwork            = "tcp"
 	defaultBasePath           = "/"
 	defaultMaxRequestBodySize = 4 * 1024 * 1024


### PR DESCRIPTION
## Summary
- fix Ping handler template to use `"ping"` key for the default response

## Testing
- `go vet ./...` *(fails: lookup proxy.golang.org: no such host)*
- `go test ./...` *(fails: lookup proxy.golang.org: no such host)*